### PR TITLE
Nightlyをもっと気軽に試せるようにしたい

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ obj
 !/tools/Nuget.template.config
 !/tools/Dockerfile
 
+/nightly/*
+!/nightly/.gitkeep
+
 try-net7-dotnet-webassembly.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,51 @@
 VERSION=preview7
 RUNTIME_DEST=runtime/$(VERSION)
 
+NIGHTLY:=runtime/nightly
+
 HERE := $(dir $(abspath "."))
 
 tools/dotnet-install.sh:
 	curl -o $@ -L https://dot.net/v1/dotnet-install.sh
 	chmod +x $@
 
+_dotnet7/clean:
+	-rm -r $(RUNTIME_DEST)
+
 dotnet7: tools/dotnet-install.sh
 	$< -i $(RUNTIME_DEST) -v latest -q daily --channel 7.0
+
+dotnet7/nightly:
+	$(MAKE) _dotnet7/clean dotnet7 dotnet7/install/workload/nightly RUNTIME_DEST=$(NIGHTLY)
 
 dotnet7/install/template:
 	$(RUNTIME_DEST)/dotnet new install packages/$(VERSION)/Microsoft.NET.Runtime.WebAssembly.Templates.7.0.0-dev.nupkg
 
+dotnet7/install/template/nightly:
+	$(RUNTIME_DEST)/dotnet new install --force nightly/runtime/src/mono/wasm/templates
+
 dotnet7/uninstall/template:
 	$(RUNTIME_DEST)/dotnet new uninstall Microsoft.NET.Runtime.WebAssembly.Templates
 
+dotnet7/uninstall/template/nightly:
+	$(RUNTIME_DEST)/dotnet new uninstall nightly/runtime/src/mono/wasm/templates
+
 dotnet7/install/workload:
 	$(RUNTIME_DEST)/dotnet workload install --skip-manifest-update --no-cache --configfile tools/Nuget.$(VERSION).config wasm-tools
+
+dotnet7/install/workload/nightly:
+	$(RUNTIME_DEST)/dotnet workload install --skip-manifest-update --no-cache wasm-tools -s https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
+
+nightly/runtime:
+	git clone --single-branch --branch main https://github.com/dotnet/runtime.git nightly/runtime
+
+nightly/runtime/checkout: nightly/runtime
+	cd nightly/runtime; git fetch -n -p origin main
+	cd nightly/runtime; git checkout $(NIGHTLY_COMMIT)
+
+nightly/install/template:
+	$(MAKE) nightly/runtime/checkout NIGHTLY_COMMIT=$$(cat runtime/nightly/packs/Microsoft.NETCore.App.Runtime.Mono.browser-wasm/*/Microsoft.NETCore.App.versions.txt | head -n 1)
+	$(MAKE) dotnet7/install/template/nightly RUNTIME_DEST=$(NIGHTLY)
 
 init/workspace:
 	cat try-net7-dotnet-webassembly.code-workspace.template | sed -E "s:<!-- CWD -->:$(HERE):" > try-net7-dotnet-webassembly.code-workspace

--- a/README.md
+++ b/README.md
@@ -19,14 +19,39 @@ https://github.com/dotnet/runtime で開発が行われている [wasm](https://
   - ${shorthash or release}
     - 環境を分離するために dotnet-install scripts でダウンロードした.NET SDKを配置する箇所
     - ex: preview7
+  - nightly
+    - nightlyなパッケージをインストールする砂場
 - packages
   - ${shorthash or release}
     - dotnet/runtime をビルドして得られた artifacts/packages/Release/Shipping 以下を展開する場所
     - ex: preview7/*.nupkg
+- nightly
+  - runtime
+    - dotnet/runtime リポジトリのclone先
 
 ## How to try
 
+### Easy (Recommended)
+
+#### Docker
+
+- tools/Dockerfileを使ってBuild
+
+or 
+
+- Docker HubからPull
+  - https://hub.docker.com/r/yamachu/dotnet-wasm-tools
+
+#### Use pre-built packages
+
+```sh
+# 初期インストール
+$ make dotnet7/nightly nightly/install/template
+# 試し終わったらTemplate削除した方が良い
+$ make dotnet7/uninstall/template/nightly
+```
+
+### Hard
+
 1. https://github.com/dotnet/runtime/tree/main/docs/workflow/requirements を見て環境構築する
 2. dotnet/runtime をビルドする
-
-は大変なので、Dockerfileを使用しビルドするか、Docker Hubで配布しているImageを使用しビルドする


### PR DESCRIPTION
workloadのnightlyが配布されてるfeedないかなって調べてたら
https://github.com/dotnet/runtime/tree/main/src/mono/wasi#2-obtain-a-suitable-net-build-toolchain
に書いてあった

このfeed使えばtemplateを自分で用意するだけで遊べそうなので、これをメインのやり方にしてもいいんじゃないかな